### PR TITLE
Remove FIFO configuration for ICA event queue

### DIFF
--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -63,8 +63,7 @@ export const DEFAULT_MAX_ICA_STATE_CHANGE_API_CONCURRENCY = 5;
 // The SQS queue pushes directly to the handleAnalysisStateChange step function
 // The SQS name should be noted since the ARN is required when
 // setting up the notifications of the project
-// FIFO based queues must end in '.fifo'
-export const DEFAULT_EXTERNAL_ICA_EVENT_SQS_NAME = 'Icav2WesAnalysisSqsQueue.fifo';
+export const DEFAULT_EXTERNAL_ICA_EVENT_SQS_NAME = 'Icav2WesAnalysisSqsQueue';
 export const DEFAULT_EXTERNAL_ICA_EVENT_PIPE_NAME = 'Icav2WesSqsEventPipe';
 export const DEFAULT_ICA_AWS_ACCOUNT_NUMBER = '079623148045';
 

--- a/infrastructure/stage/sqs/index.ts
+++ b/infrastructure/stage/sqs/index.ts
@@ -18,11 +18,9 @@ export function createMonitoredQueue(scope: Construct, props: SqsQueueConstructP
       enforceSSL: true,
       visibilityTimeout: props.queueVizTimeout,
       receiveMessageWaitTime: props.receiveMessageWaitTime,
-      fifo: props.isFifoQueue,
-      contentBasedDeduplication: props.isFifoQueue,
     },
     dlqProps: {
-      queueName: props.queueName + '-dlq',
+      queueName: `${props.queueName}-dlq`,
       enforceSSL: true,
       visibilityTimeout: props.queueVizTimeout,
     },
@@ -42,7 +40,6 @@ export function createExternalIcaMonitoredQueue(
     slackTopic: props.slackTopic,
     dlqMessageThreshold: props.dlqMessageThreshold,
     queueVizTimeout: props.queueVizTimeout,
-    isFifoQueue: props.isFifoQueue,
   });
 
   // Grant send message permissions to the ICA account

--- a/infrastructure/stage/sqs/interfaces.ts
+++ b/infrastructure/stage/sqs/interfaces.ts
@@ -12,8 +12,6 @@ export interface SqsQueueConstructProps {
   queueVizTimeout: Duration;
   /* For long polling */
   receiveMessageWaitTime?: Duration;
-  /* Is fifo queue */
-  isFifoQueue?: boolean;
 }
 
 export interface IcaSqsQueueConstructProps extends SqsQueueConstructProps {

--- a/infrastructure/stage/stateful-application-stack.ts
+++ b/infrastructure/stage/stateful-application-stack.ts
@@ -85,10 +85,9 @@ export class StatefulApplicationStack extends cdk.Stack {
       icaAwsAccountNumber: DEFAULT_ICA_AWS_ACCOUNT_NUMBER,
       queueVizTimeout: DEFAULT_ICA_STATE_CHANGE_MAX_TIMEOUT,
       dlqMessageThreshold: 1,
-      isFifoQueue: true,
     });
 
-    // // Build the ICAv2 WES database
+    // Build the ICAv2 WES database
     buildICAv2WesDb(this, {
       tableName: props.wesTableName,
       indexNames: props.indexNames,


### PR DESCRIPTION
-----
Why This Change
* Reverts the configuration of the ICA event SQS queue as a FIFO queue.
* The ICA event queue is not intended to operate as a FIFO queue.

-----
Changes Made
* Removed the '.fifo' suffix from the SQS queue name constant.
* Disabled FIFO and content-based deduplication properties in the SQS queue construct.
* Updated SQS queue interfaces and removed the `isFifoQueue` property from usages.