### PR TITLE
Migrates to ICAv2 WES Orcabus ID for direct lookups

### DIFF
--- a/app/lambdas/add_portal_run_id_attributes_py/add_portal_run_id_attributes.py
+++ b/app/lambdas/add_portal_run_id_attributes_py/add_portal_run_id_attributes.py
@@ -23,7 +23,7 @@ def handler(event, context):
     :param context:
     :return:
     """
-
+    # Inputs
     output_uri = event.get("outputUri")
     portal_run_id = event.get("portalRunId")
 

--- a/app/lambdas/get_icav2_wes_object_py/get_icav2_wes_object.py
+++ b/app/lambdas/get_icav2_wes_object_py/get_icav2_wes_object.py
@@ -8,21 +8,24 @@ Get the ICAv2 WES Object
 from typing import Dict, Any
 
 # Layer imports
-from orcabus_api_tools.icav2_wes import get_icav2_wes_analysis_by_name
+from orcabus_api_tools.icav2_wes import get_icav2_wes_request
+from orcabus_api_tools.icav2_wes.globals import ANALYSES_ENDPOINT
 
 
 def handler(event, context) -> Dict[str, Any]:
     """
-    Get the ICAv2 WES Object
+    Get the ICAv2 WES Object by its orcabus ID (direct hash key lookup).
+    Falls back to name-based lookup for backwards compatibility.
     """
-    # Get the analysis name from the event
-    name = event.get("name")
-    if not name:
-        raise ValueError("No analysis name provided")
+    # Prefer icav2WesOrcabusId for direct lookup by DynamoDB hash key
+    icav2_wes_orcabus_id = event.get("icav2WesOrcabusId")
 
-    # Get the ICAv2 WES Object
-    icav2_wes_object = get_icav2_wes_analysis_by_name(
-        analysis_name=name
+    if not icav2_wes_orcabus_id:
+        raise ValueError("No icav2WesOrcabusId provided")
+
+    # Direct GET by ID — uses DynamoDB hash key, avoids GSI query
+    icav2_wes_object = get_icav2_wes_request(
+        f"{ANALYSES_ENDPOINT}/{icav2_wes_orcabus_id}"
     )
 
     return {

--- a/app/lambdas/get_icav2_wes_object_py/get_icav2_wes_object.py
+++ b/app/lambdas/get_icav2_wes_object_py/get_icav2_wes_object.py
@@ -15,7 +15,6 @@ from orcabus_api_tools.icav2_wes.globals import ANALYSES_ENDPOINT
 def handler(event, context) -> Dict[str, Any]:
     """
     Get the ICAv2 WES Object by its orcabus ID (direct hash key lookup).
-    Falls back to name-based lookup for backwards compatibility.
     """
     # Prefer icav2WesOrcabusId for direct lookup by DynamoDB hash key
     icav2_wes_orcabus_id = event.get("icav2WesOrcabusId")

--- a/app/lambdas/get_pipeline_type_py/get_pipeline_type.py
+++ b/app/lambdas/get_pipeline_type_py/get_pipeline_type.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Get the icav2 analysis object from the workflow name
+Get the icav2 analysis object from the workflow orcabus id
 """
 
 # Standard Library Imports
@@ -12,24 +12,26 @@ from wrapica.project_analysis import get_analysis_obj_from_analysis_id
 
 # Layer imports
 from icav2_tools import set_icav2_env_vars
-from orcabus_api_tools.icav2_wes import get_icav2_wes_analysis_by_name
+from orcabus_api_tools.icav2_wes import get_icav2_wes_request
+from orcabus_api_tools.icav2_wes.globals import ANALYSES_ENDPOINT
 
 
 def handler(event, context) -> Dict[str, Any]:
     """
-    Get the ICAv2 WES Object
+    Get the ICAv2 WES Object and determine the pipeline language
     """
     # Set the environment variables for icav2
     set_icav2_env_vars()
 
-    # Get the analysis name from the event
-    name = event.get("name")
-    if not name:
-        raise ValueError("No analysis name provided")
+    # Prefer icav2WesOrcabusId for direct lookup by DynamoDB hash key
+    icav2_wes_orcabus_id = event.get("icav2WesOrcabusId")
 
-    # Get the ICAv2 WES Object
-    icav2_wes_object = get_icav2_wes_analysis_by_name(
-        analysis_name=name
+    if not icav2_wes_orcabus_id:
+        raise ValueError("No icav2WesOrcabusId provided")
+
+    # Direct GET by ID — uses DynamoDB hash key, avoids GSI query
+    icav2_wes_object = get_icav2_wes_request(
+        f"{ANALYSES_ENDPOINT}/{icav2_wes_orcabus_id}"
     )
 
     # Get the pipeline id

--- a/app/lambdas/handle_ica_event_py/handle_ica_event.py
+++ b/app/lambdas/handle_ica_event_py/handle_ica_event.py
@@ -78,7 +78,6 @@ def handle_ica_execution(
         icav2_wes_orcabus_id: str,
         status: str,
         icav2_analysis_id: str,
-        name: str,
         error_message: str,
         message_receipt_handle_token: str,
         context: DurableContext
@@ -118,7 +117,6 @@ def handle_ica_execution(
                 {
                     "icav2AnalysisId": icav2_analysis_id,
                     "status": status,
-                    "name": name,
                     "errorMessage": error_message,
                     "icav2WesOrcabusId": icav2_wes_orcabus_id,
                     "messageReceiptHandleToken": message_receipt_handle_token
@@ -189,7 +187,6 @@ def handler(event, context: DurableContext):
             icav2_wes_orcabus_id=icav2_wes_orcabus_id,
             status = payload.get("status"),
             icav2_analysis_id = payload.get("id"),
-            name = payload.get("userReference"),
             error_message = payload.get("summary"),
             message_receipt_handle_token = record.get("receiptHandle"),
             context=context,

--- a/app/lambdas/update_status_on_wes_api_py/update_status_on_wes_api.py
+++ b/app/lambdas/update_status_on_wes_api_py/update_status_on_wes_api.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 """
-Given an analysis id, find the analysis id in the database and update the status on the ICAv2 wes api.
+Given an orcabus id, update the status on the ICAv2 wes api.
+Uses the icav2WesOrcabusId directly for hash key lookup, avoiding GSI queries.
 """
 # Standard imports
 from tempfile import NamedTemporaryFile
@@ -16,15 +17,11 @@ from pathlib import Path
 
 # Layer imports
 from orcabus_api_tools.icav2_wes import (
-    get_icav2_wes_analysis_by_name,
     update_icav2_wes_analysis_status
 )
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
-
-# Globals
-ICAV2_WES_ORCABUS_ID_TAG_NAME = 'icav2_wes_orcabus_id'
 
 # Set up logging
 logger = logging.getLogger()
@@ -37,14 +34,18 @@ S3_ANALYSIS_ARTEFACTS_BUCKET_NAME_ENV_VAR = 'S3_ANALYSIS_ARTEFACTS_BUCKET_NAME'
 
 def handler(event, context) -> Dict:
     """
-    Update the status of analysis on the ICAv2 WES API
+    Update the status of analysis on the ICAv2 WES API.
+    Uses icav2WesOrcabusId for direct DynamoDB hash key lookup.
     :param event:
     :param context:
     :return:
     """
 
-    # Get the name from the event
-    name = event.get("name")
+    # Get the orcabus id from the event (direct hash key — no GSI query needed)
+    icav2_wes_orcabus_id = event.get("icav2WesOrcabusId")
+
+    if not icav2_wes_orcabus_id:
+        raise ValueError("No icav2WesOrcabusId provided")
 
     # Get the status from the event
     status = event.get("status")
@@ -63,10 +64,8 @@ def handler(event, context) -> Dict:
     # And then we add the S3 uri to the database.
     s3_payload_uri = None
     if error_message is not None:
-        # icav2 analysis id might be none if this is a CreateFailure
-        # use the orcabus id instead
-        if icav2_analysis_id is None:
-            icav2_analysis_id = get_icav2_wes_analysis_by_name(name)['id']
+        # Use icav2_analysis_id for the error log path, fall back to orcabus id
+        error_log_id = icav2_analysis_id if icav2_analysis_id is not None else icav2_wes_orcabus_id
         # Get the current date and upload path
         logger.info("Uploading the error logs to S3")
         now = datetime.now(timezone.utc)
@@ -75,7 +74,7 @@ def handler(event, context) -> Dict:
             f"year={now.year}" /
             f"month={now.month:02d}" /
             f"day={now.day:02d}" /
-            f"{icav2_analysis_id}.txt"
+            f"{error_log_id}.txt"
         )
         # Save the analysis object to a temporary file
         with (
@@ -100,16 +99,11 @@ def handler(event, context) -> Dict:
             None, None, None
         )))
 
-    # Get the analysis object
-    analysis_object = get_icav2_wes_analysis_by_name(
-        analysis_name=name
-    )
-
-    # Update the status on the ICAv2 WES API
+    # Update the status on the ICAv2 WES API directly using the orcabus id
     update_response = update_icav2_wes_analysis_status(
-        analysis_object['id'],
+        icav2_wes_orcabus_id,
         **dict(filter(
-            lambda kv_iter_: kv_iter_ is not None,
+            lambda kv_iter_: kv_iter_[1] is not None,
             {
                 # Keyword (packed) args in camelCase
                 "status": status,

--- a/app/step-functions-templates/handle_corrupted_files_sfn_template.asl.json
+++ b/app/step-functions-templates/handle_corrupted_files_sfn_template.asl.json
@@ -5,7 +5,7 @@
       "Type": "Pass",
       "Next": "Get portal run id (corrupted files check)",
       "Assign": {
-        "name": "{% $states.input.name %}"
+        "icav2WesOrcabusId": "{% $states.input.icav2WesOrcabusId %}"
       }
     },
     "Get portal run id (corrupted files check)": {
@@ -15,7 +15,7 @@
       "Arguments": {
         "FunctionName": "${__get_icav2_wes_object_lambda_function_arn__}",
         "Payload": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Retry": [

--- a/app/step-functions-templates/handle_filemanager_sfn_template.asl.json
+++ b/app/step-functions-templates/handle_filemanager_sfn_template.asl.json
@@ -5,7 +5,7 @@
       "Type": "Pass",
       "Next": "Get output dir and portal run id",
       "Assign": {
-        "name": "{% $states.input.name %}",
+        "icav2WesOrcabusId": "{% $states.input.icav2WesOrcabusId %}",
         "fmWaitCount": 0
       }
     },
@@ -15,7 +15,7 @@
       "Arguments": {
         "FunctionName": "${__get_icav2_wes_object_lambda_function_arn__}",
         "Payload": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Retry": [

--- a/app/step-functions-templates/handle_icav2_analysis_state_change_sfn_template.asl.json
+++ b/app/step-functions-templates/handle_icav2_analysis_state_change_sfn_template.asl.json
@@ -8,7 +8,6 @@
       "Assign": {
         "icav2AnalysisId": "{% $states.input.icav2AnalysisId %}",
         "status": "{% $states.input.status %}",
-        "name": "{% $states.input.name %}",
         "errorMessage": "{% $states.input.errorMessage %}",
         "icav2WesOrcabusId": "{% $states.input.icav2WesOrcabusId %}",
         "messageReceiptHandleToken": "{% $states.input.messageReceiptHandleToken %}"
@@ -58,7 +57,7 @@
       "Arguments": {
         "StateMachineArn": "${__handle_nextflow_files_state_machine_arn__}",
         "Input": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Next": "Handle Filemanager (sync)",
@@ -75,7 +74,7 @@
       "Arguments": {
         "StateMachineArn": "${__handle_filemanager_state_machine_arn__}",
         "Input": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Next": "Get task summaries (false)"
@@ -124,7 +123,7 @@
       "Arguments": {
         "FunctionName": "${__update_status_on_wes_api_lambda_function_arn__}",
         "Payload": {
-          "name": "{% $name %}",
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}",
           "status": "{% /* https://try.jsonata.org/WVD2IGYzV */\n(\n  $statusMap := {\n    \"INITIALIZING\": \"STARTING\",\n    \"IN_PROGRESS\": \"RUNNING\",\n    \"SUCCEEDED\": \"SUCCEEDED\",\n    \"FAILED\": \"FAILED\",\n    \"FAILED_FINAL\": \"FAILED\",\n    \"ABORTED\": \"ABORTED\"\n  };\n  $lookup($statusMap, $status)\n) %}",
           "icav2AnalysisId": "{% $icav2AnalysisId %}",
           "errorMessage": "{% $status != 'SUCCEEDED' ? $errorMessage : null %}",
@@ -177,7 +176,7 @@
       "Arguments": {
         "StateMachineArn": "${__handle_corrupted_files_state_machine_arn__}",
         "Input": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Next": "Update WES API",

--- a/app/step-functions-templates/handle_nextflow_files_sfn_template.asl.json
+++ b/app/step-functions-templates/handle_nextflow_files_sfn_template.asl.json
@@ -4,12 +4,12 @@
   "States": {
     "Get Env vars": {
       "Type": "Pass",
-      "Next": "Get ICAv2 analysis object from name",
+      "Next": "Get ICAv2 analysis object from id",
       "Assign": {
-        "name": "{% $states.input.name %}"
+        "icav2WesOrcabusId": "{% $states.input.icav2WesOrcabusId %}"
       }
     },
-    "Get ICAv2 analysis object from name": {
+    "Get ICAv2 analysis object from id": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Output": {
@@ -18,7 +18,7 @@
       "Arguments": {
         "FunctionName": "${__get_pipeline_type_lambda_function_arn__}",
         "Payload": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Retry": [
@@ -57,7 +57,7 @@
       "Arguments": {
         "FunctionName": "${__get_icav2_wes_object_lambda_function_arn__}",
         "Payload": {
-          "name": "{% $name %}"
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}"
         }
       },
       "Retry": [

--- a/app/step-functions-templates/launch_icav2_analysis_sfn_template.asl.json
+++ b/app/step-functions-templates/launch_icav2_analysis_sfn_template.asl.json
@@ -21,7 +21,7 @@
         "FunctionName": "${__update_status_on_wes_api_lambda_function_arn__}",
         "Payload": {
           "status": "RUNNABLE",
-          "name": "{% $name %}",
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}",
           "stepsLaunchExecutionArn": "{% $states.context.Execution.Id %}"
         }
       },
@@ -227,7 +227,7 @@
       "Arguments": {
         "FunctionName": "${__update_status_on_wes_api_lambda_function_arn__}",
         "Payload": {
-          "name": "{% $name %}",
+          "icav2WesOrcabusId": "{% $icav2WesOrcabusId %}",
           "status": "FAILED",
           "errorType": "{% $errorType ? $errorType : null %}",
           "errorMessage": "{% $errorMessage ? $errorMessage : null %}"


### PR DESCRIPTION
This pull request refactors the system to consistently use `icav2WesOrcabusId` for identifying and interacting with ICAv2 WES objects, moving away from name-based lookups. This change ensures more direct and efficient data retrieval, leveraging primary key lookups in DynamoDB and avoiding less optimal Global Secondary Index (GSI) queries.

Key changes include:
- Updates `get_icav2_wes_object`, `get_pipeline_type`, `update_status_on_wes_api`, and `handle_ica_event` lambdas to consume `icav2WesOrcabusId` as a primary input, replacing the `name` parameter.
- Modifies various Step Function templates (`handle_corrupted_files`, `handle_filemanager`, `handle_icav2_analysis_state_change`, `handle_nextflow_files`, `launch_icav2_analysis`) to pass `icav2WesOrcabusId` through their state transitions.
- Removes outdated logic for name-based ICAv2 WES analysis lookups, making `icav2WesOrcabusId` a required input for relevant lambdas.
- Adds a minor comment to the `add_portal_run_id_attributes` lambda for input clarity.

Relates to enhancement/use-ids-over-name-inputs