### PR TITLE
Update platform-cdk to use version 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.252.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.7.2",
+    "@orcabus/platform-cdk-constructs": "1.9.1",
     "aws-cdk-lib": "^2.263.0",
     "constructs": "^10.8.1",
     "sqs-dlq-monitoring": "^1.2.25"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.252.0-alpha.0
         version: 2.252.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.7.2
-        version: 1.7.2(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
+        specifier: 1.9.1
+        version: 1.9.1(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
       aws-cdk-lib:
         specifier: ^2.263.0
         version: 2.263.0(constructs@10.8.1)
@@ -449,8 +449,8 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@orcabus/platform-cdk-constructs@1.7.2':
-    resolution: {integrity: sha512-oayS7Cpe94ZrwLIzKgDuHC1uOeN8r88CpgJDo3NIOyLp4wVCgAtTFPA+GL/mAL43PICLC++rfQcUFcgbx60IhQ==}
+  '@orcabus/platform-cdk-constructs@1.9.1':
+    resolution: {integrity: sha512-KM2KvnM3eqaT97iFgy3Lz6KYBsaikl4VU2PKXFJwVCqJKSj0uWyXU5DxwHQgiENn7AbiDu+weMXQDE9vCUjnyw==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2343,7 +2343,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.7.2(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)':
+  '@orcabus/platform-cdk-constructs@1.9.1(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.252.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
       aws-cdk-lib: 2.263.0(constructs@10.8.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,6 @@ minimumReleaseAgeExclude:
   - aws-cdk-lib@2.256.1
   - aws-cdk@2.1124.1
   - js-yaml@4.1.2
+  - '@orcabus/platform-cdk-constructs@1.9.1'
 overrides:
   js-yaml@<=4.1.1: ^4.1.2


### PR DESCRIPTION
Upgrade to wrapica 2.47.0, use of samplesheet which now uses absolute paths instead of relative paths to point to files