### PR TITLE
fix: stream files in is_file_corrupted to bound memory/disk usage

### DIFF
--- a/app/lambdas/is_file_corrupted_py/is_file_corrupted.py
+++ b/app/lambdas/is_file_corrupted_py/is_file_corrupted.py
@@ -11,20 +11,59 @@ We perform the following checks:
 3. If the file is anything else, we check if the last char is a newline char
 
 If the file is corrupted we return with the s3 uri with the key corruptedS3Uri
+
+Implementation note
+-------------------
+Files may be arbitrarily large, so we never hold the full (compressed or
+decompressed) contents in memory. Instead we stream the download in fixed-size
+chunks and:
+
+  * gzip files      -> feed each chunk through an incremental decompressor and
+                       discard the output; a corrupt stream raises while
+                       decompressing.
+  * json files      -> stream (decompressed if needed) to a temp file on disk,
+                       then parse from disk.
+  * html files      -> keep only the trailing bytes to confirm the closing tag.
+  * everything else -> remember only the final byte to confirm a trailing
+                       newline.
 """
 # Standard imports
-from json import JSONDecodeError
+import zlib
+from json import JSONDecodeError, load as json_load
 from tempfile import NamedTemporaryFile
 import requests
-from gzip import decompress, BadGzipFile
-import json
 
 # Layer imports
 from orcabus_api_tools.filemanager import (
     get_presigned_url_from_ingest_id,
-    get_file_object_from_ingest_id, get_s3_uri_from_ingest_id
+    get_file_object_from_ingest_id,
+    get_s3_uri_from_ingest_id,
 )
 from orcabus_api_tools.filemanager.models import FileObject
+
+# How many bytes we read from the network at a time.
+CHUNK_SIZE = 1024 * 1024  # 1 MiB
+
+# gzip streams use a zlib window with the gzip header (16 + MAX_WBITS).
+_GZIP_WBITS = 16 + zlib.MAX_WBITS
+
+# Number of trailing bytes we retain to validate the HTML closing tag.
+# Kept comfortably larger than "</html>" plus any trailing whitespace.
+_HTML_TAIL_BYTES = 1024
+_HTML_CLOSING_TAG = b"</html>"
+
+
+def _iter_response_chunks(presigned_url: str):
+    """
+    Stream the response body in fixed-size byte chunks without buffering the
+    whole payload in memory.
+    """
+    with requests.get(presigned_url, stream=True) as response:
+        response.raise_for_status()
+        for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+            if chunk:
+                yield chunk
+
 
 def handler(event, context):
     """
@@ -36,70 +75,74 @@ def handler(event, context):
     # Get the file object
     file_object: FileObject = get_file_object_from_ingest_id(ingest_id)
 
-    # Get the file object
+    # Get the presigned url
     presigned_url = get_presigned_url_from_ingest_id(ingest_id)
 
-    # Download the file
-    local_file_obj = NamedTemporaryFile()
-    with open(local_file_obj.name, 'w') as tmp_h:
-        if file_object["key"].endswith(".gz"):
+    key = file_object["key"]
+    is_gzipped = key.endswith(".gz")
+    is_json = key.endswith(".json.gz") or key.endswith("json")
+    is_html = key.endswith(".html")
+
+    corrupted = {"corruptedS3Uri": get_s3_uri_from_ingest_id(ingest_id)}
+    not_corrupted = {"corruptedS3Uri": None}
+
+    # ------------------------------------------------------------------
+    # JSON: we need the full (decompressed) document to validate it, so we
+    # stream it to disk first and then parse it from disk. We never hold the
+    # entire download in memory at once.
+    # ------------------------------------------------------------------
+    if is_json:
+        decompressor = zlib.decompressobj(_GZIP_WBITS) if is_gzipped else None
+        with NamedTemporaryFile(suffix=".json") as tmp:
             try:
-                tmp_h.write(
-                    decompress(
-                        requests.get(
-                            presigned_url
-                        ).content
-                    ).decode()
-                )
-            except (BadGzipFile, EOFError):
-                return {
-                    "corruptedS3Uri": get_s3_uri_from_ingest_id(ingest_id)
-                }
-        else:
-            tmp_h.write(
-                requests.get(
-                    presigned_url
-                ).text
-            )
+                for chunk in _iter_response_chunks(presigned_url):
+                    if decompressor is not None:
+                        tmp.write(decompressor.decompress(chunk))
+                    else:
+                        tmp.write(chunk)
+                if decompressor is not None:
+                    tmp.write(decompressor.flush())
+            except (zlib.error, EOFError):
+                # Corrupt gzip stream
+                return corrupted
 
-    # If the file is a JSON file, we try to load it
-    if (
-            file_object["key"].endswith(".json.gz") or
-            file_object["key"].endswith("json")
-    ):
-        with open(local_file_obj.name, 'r') as json_h:
+            tmp.flush()
+            tmp.seek(0)
             try:
-                json.load(json_h)
-            except JSONDecodeError:
-                return {
-                    "corruptedS3Uri": get_s3_uri_from_ingest_id(ingest_id)
-                }
-        return {
-            "corruptedS3Uri": None
-        }
+                json_load(tmp)
+            except (JSONDecodeError, UnicodeDecodeError):
+                return corrupted
+        return not_corrupted
 
-    # HTML Files may not have a line ending, confirm that they end in '</html>'
-    if (
-        file_object["key"].endswith(".html")
-    ):
-        with open(local_file_obj.name, 'r') as html_h:
-            file_contents = html_h.read()
-            if file_contents.rstrip().endswith("</html>"):
-                return {
-                    "corruptedS3Uri": None
-                }
-            return {
-                "corruptedS3Uri": get_s3_uri_from_ingest_id(ingest_id)
-            }
+    # ------------------------------------------------------------------
+    # Non-JSON: we only ever need the trailing bytes of the (decompressed)
+    # content, so we stream through and retain just the tail.
+    # ------------------------------------------------------------------
+    decompressor = zlib.decompressobj(_GZIP_WBITS) if is_gzipped else None
+    tail = b""
+    tail_limit = _HTML_TAIL_BYTES if is_html else 1
 
-    # Check if the file's last file character is a new line
-    with open(local_file_obj.name, 'r') as file_h:
-        file_str = file_h.read()
-        if not file_str.endswith("\n"):
-            return {
-                "corruptedS3Uri": get_s3_uri_from_ingest_id(ingest_id)
-            }
+    try:
+        for chunk in _iter_response_chunks(presigned_url):
+            data = decompressor.decompress(chunk) if decompressor is not None else chunk
+            if data:
+                tail = (tail + data)[-tail_limit:]
+        if decompressor is not None:
+            data = decompressor.flush()
+            if data:
+                tail = (tail + data)[-tail_limit:]
+    except (zlib.error, EOFError):
+        # Corrupt gzip stream
+        return corrupted
 
-    return {
-        "corruptedS3Uri": None
-    }
+    # HTML files may not have a line ending; confirm they end in '</html>'.
+    if is_html:
+        if tail.rstrip().endswith(_HTML_CLOSING_TAG):
+            return not_corrupted
+        return corrupted
+
+    # Everything else: the final character must be a newline.
+    if not tail.endswith(b"\n"):
+        return corrupted
+
+    return not_corrupted


### PR DESCRIPTION
## Summary

`is_file_corrupted` assumed the file under inspection was small and buffered the entire file in memory before running its corruption checks. For gzip files it also held the full decompressed payload in memory. A large corrupted file (exactly the case this Lambda exists to catch) could exhaust the Lambda's memory or `/tmp` disk and crash instead of cleanly reporting corruption.

This change streams the download in fixed-size (1 MiB) chunks and only retains what each check actually needs:

- **gzip** — chunks are fed through an incremental `zlib.decompressobj`; output is discarded (or tail-trimmed). A truncated/corrupt stream raises and maps to corrupted.
- **newline check** (default) — retains only the final byte.
- **HTML** — retains only the trailing bytes to confirm the `</html>` closing tag.
- **JSON** — streams (decompressing on the fly for `.gz`) to a temp file and parses from disk, avoiding multiple full-size in-memory copies.

## Behavior notes

- Switched to working in bytes throughout so we don't decode a whole large file just to inspect its tail.
- Added `UnicodeDecodeError` to the JSON parse guard so a non-UTF-8 JSON payload is treated as corrupted rather than crashing.

## Testing

- `python3 -m py_compile` passes.
- pre-commit hooks (prettier, detect-secrets, etc.) passed on commit.
- No existing tests reference this Lambda.

Closes #103